### PR TITLE
Fix type of fee in SPECIFICATION.md

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -34,7 +34,7 @@ scripts and JS injections. It returns a JSON response with the following data:
 ```json
 {
     "description": "(example) The Reference Pool allows you to pool with low fees, paying out daily using Chia.",
-    "fee": 0.01,
+    "fee": "0.01",
     "logo_url": "https://www.chia.net/img/chia_logo.svg",
     "minimum_difficulty": 10,
     "name": "The Reference Pool",


### PR DESCRIPTION
According to `pool/pool_server.py`, type of `fee` in `/pool_info` response seems to be `str`.

```python
    async def get_pool_info(self, _) -> web.Response:
        res: PoolInfo = PoolInfo(
            "The Reference Pool",
            "https://www.chia.net/img/chia_logo.svg",
            uint64(self.pool.min_difficulty),
            uint32(self.pool.relative_lock_height),
            "1.0.0",
            str(self.pool.pool_fee),
            "(example) The Reference Pool allows you to pool with low fees, paying out daily using Chia.",
            self.pool.default_target_puzzle_hash,
        )
        return obj_to_response(res)
```