### PR TITLE
Adding plot records and estimated pool netspace

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,3 +19,5 @@ confirmation_security_threshold: 6
 payment_interval: 600
 max_additions_per_transaction: 400
 number_of_partials_target: 30
+plot_records:
+  time_to_delete: 86400

--- a/pool/pool.py
+++ b/pool/pool.py
@@ -474,10 +474,10 @@ class Pool:
                     plot_records: Optional[PlotRecord] = await self.store.get_plot_records(farmer.launcher_id)
                     for plot in plot_records:
                     
-                        # This is our net space calculation based on 0.000762*k*2^k
-                        kb_estimation = (0.000762*plot.plot_size) * pow(2, plot.plot_size)
-                        total_size += kb_estimation/1000000;
-                        #self.log.info(f"Farmer {farmer.launcher_id} -- k{plot.plot_size} plot -- {round(kb_estimation,3)} kib -- {round((kb_estimation/1000000),3)} gib")
+                        # This is our net space calculation based on 0.000777*k*2^k
+                        kb_estimation = (0.000777*plot.plot_size) * pow(2, plot.plot_size)
+                        total_size += kb_estimation/1024/1024;
+                        #self.log.info(f"Farmer {farmer.launcher_id} -- k{plot.plot_size} plot -- {round(kb_estimation,3)} kib -- {round((kb_estimation/1024/1024),3)} gib")
                         
                     total_plots+=len(plot_records);
 


### PR DESCRIPTION
This is a specific use case for our pool - but I figured I would create a PR and see if anyone would find it useful.  Feel free to ignore if it's not something that your interested in - or you can update to a feature branch if you are*.

To be brief though, this adds a record keeping table in **pooldb.sqlite** for plots submitted and validated during partial submission.  We record only new plots and refresh each plot when a new partial of that plot comes in.

We also delete plots after a certain time when they go stale.  The target time should be around the time you expect each plot to send a new partial.  This way we only keep valid and active plots in the records for each farmer.  The k size is also recorded so we can accurately estimate the pool netspace over a 24 hour window (or the window time for a single partial to be submitted).

We can use the plot records for various things including updating frontend applications for the user.  Our pool was looking for a way to display active plots for our users for pool related gaming activities and this was the resulting code.