### PR TITLE
FarmerRecord doesn't have "suggested_difficulty"

### DIFF
--- a/pool/pool.py
+++ b/pool/pool.py
@@ -642,7 +642,7 @@ class Pool:
             )
             response_dict["suggested_difficulty"] = is_new_value
             if is_new_value:
-                farmer_dict["suggested_difficulty"] = request.payload.suggested_difficulty
+                farmer_dict["difficulty"] = request.payload.suggested_difficulty
 
         self.log.info(f"Updated farmer: {response_dict}")
         await self.store.add_farmer_record(FarmerRecord.from_json_dict(farmer_dict))


### PR DESCRIPTION
```FarmerRecord.from_json_dict(farmer_dict)``` won't work as FarmerRecord has "difficulty" but not "suggested_difficulty"