### PR TITLE
Introducing AbstractPoolStore and allow pool users to plug in their own PoolStore implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Several things are customizable in this pool reference. This includes:
 * Fees to take, and how much to pay in blockchain fees  
 * How farmers' points are counted when paying (PPS, PPLNS, etc)
 * How farmers receive payouts (XCH, BTC, ETH, etc), and how often
+* What store (DB) is used - by default it's an SQLite db. Users can use their own store implementations, based on 
+  `AbstractPoolStore`, by supplying them to `pool_server.start_pool_server`
 
 However, some things cannot be changed. These are described in SPECIFICATION.md, and mostly relate to validation,
 protocol, and the singleton format for smart coins. 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cd pool-reference
 python3 -m venv ./venv
 source ./venv/bin/activate
 pip install ../chia-blockchain/ 
-sudo CHIA_ROOT="/your/home/dir/.chia/testnet7" ./venv/bin/python pool/pool_server.py
+sudo CHIA_ROOT="/your/home/dir/.chia/testnet7" ./venv/bin/python -m pool
 ```
 
 You should see something like this when starting, but no errors:

--- a/pool/__main__.py
+++ b/pool/__main__.py
@@ -1,0 +1,2 @@
+from pool.pool_server import main
+main()

--- a/pool/pool.py
+++ b/pool/pool.py
@@ -43,11 +43,11 @@ from chia.pools.pool_puzzles import (
     launcher_id_to_p2_puzzle_hash,
 )
 
-from difficulty_adjustment import get_new_difficulty
-from singleton import create_absorb_transaction, get_singleton_state, get_coin_spend
-from store import PoolStore
-from record import FarmerRecord
-from util import error_dict
+from .difficulty_adjustment import get_new_difficulty
+from .singleton import create_absorb_transaction, get_singleton_state, get_coin_spend
+from .store import PoolStore
+from .record import FarmerRecord
+from .util import error_dict
 
 
 class Pool:

--- a/pool/pool.py
+++ b/pool/pool.py
@@ -45,7 +45,7 @@ from chia.pools.pool_puzzles import (
 
 from .difficulty_adjustment import get_new_difficulty
 from .singleton import create_absorb_transaction, get_singleton_state, get_coin_spend
-from .store import PoolStore
+from .store.sqlite_store import PoolStore
 from .record import FarmerRecord
 from .util import error_dict
 

--- a/pool/pool.py
+++ b/pool/pool.py
@@ -52,7 +52,7 @@ from .util import error_dict
 
 
 class Pool:
-    def __init__(self, config: Dict, constants: ConsensusConstants):
+    def __init__(self, config: Dict, constants: ConsensusConstants, pool_store: Optional[AbstractPoolStore] = None):
         self.follow_singleton_tasks: Dict[bytes32, asyncio.Task] = {}
         self.log = logging
         # If you want to log to a file: use filename='example.log', encoding='utf-8'
@@ -72,7 +72,7 @@ class Pool:
         self.config = config
         self.constants = constants
 
-        self.store: AbstractPoolStore = SqlitePoolStore()
+        self.store: AbstractPoolStore = pool_store or SqlitePoolStore()
 
         self.pool_fee = pool_config["pool_fee"]
 

--- a/pool/pool.py
+++ b/pool/pool.py
@@ -45,7 +45,8 @@ from chia.pools.pool_puzzles import (
 
 from difficulty_adjustment import get_new_difficulty
 from singleton import create_absorb_transaction, get_singleton_state, get_coin_spend
-from store import FarmerRecord, PoolStore
+from store import PoolStore
+from record import FarmerRecord
 from util import error_dict
 
 

--- a/pool/pool.py
+++ b/pool/pool.py
@@ -45,7 +45,8 @@ from chia.pools.pool_puzzles import (
 
 from .difficulty_adjustment import get_new_difficulty
 from .singleton import create_absorb_transaction, get_singleton_state, get_coin_spend
-from .store.sqlite_store import PoolStore
+from .store.abstract import AbstractPoolStore
+from .store.sqlite_store import SqlitePoolStore
 from .record import FarmerRecord
 from .util import error_dict
 
@@ -71,7 +72,7 @@ class Pool:
         self.config = config
         self.constants = constants
 
-        self.store: Optional[PoolStore] = None
+        self.store: AbstractPoolStore = SqlitePoolStore()
 
         self.pool_fee = pool_config["pool_fee"]
 
@@ -168,7 +169,7 @@ class Pool:
         self.wallet_rpc_port = pool_config["wallet_rpc_port"]
 
     async def start(self):
-        self.store = await PoolStore.create()
+        await self.store.connect()
         self.pending_point_partials = asyncio.Queue()
 
         self_hostname = self.config["self_hostname"]

--- a/pool/pool_server.py
+++ b/pool/pool_server.py
@@ -28,7 +28,7 @@ from chia.util.ints import uint8, uint64, uint32
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.config import load_config
 
-from store import FarmerRecord
+from record import FarmerRecord
 from pool import Pool
 from util import error_response
 

--- a/pool/pool_server.py
+++ b/pool/pool_server.py
@@ -28,9 +28,9 @@ from chia.util.ints import uint8, uint64, uint32
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.config import load_config
 
-from record import FarmerRecord
-from pool import Pool
-from util import error_response
+from .record import FarmerRecord
+from .pool import Pool
+from .util import error_response
 
 
 def allow_cors(response: web.Response) -> web.Response:
@@ -281,8 +281,12 @@ async def stop():
     await runner.cleanup()
 
 
-if __name__ == "__main__":
+def main():
     try:
         asyncio.run(start_pool_server())
     except KeyboardInterrupt:
         asyncio.run(stop())
+
+
+if __name__ == "__main__":
+    main()

--- a/pool/record.py
+++ b/pool/record.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+from blspy import G1Element
+from chia.pools.pool_wallet_info import PoolState
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.coin_solution import CoinSolution
+from chia.util.ints import uint64
+from chia.util.streamable import streamable, Streamable
+
+
+@dataclass(frozen=True)
+@streamable
+class FarmerRecord(Streamable):
+    launcher_id: bytes32  # This uniquely identifies the singleton on the blockchain (ID for this farmer)
+    p2_singleton_puzzle_hash: bytes32  # Derived from the launcher id, delay_time and delay_puzzle_hash
+    delay_time: uint64  # Backup time after which farmer can claim rewards directly, if pool unresponsive
+    delay_puzzle_hash: bytes32  # Backup puzzlehash to claim rewards
+    authentication_public_key: G1Element  # This is the latest public key of the farmer (signs all partials)
+    singleton_tip: CoinSolution  # Last coin solution that is buried in the blockchain, for this singleton
+    singleton_tip_state: PoolState  # Current state of the singleton
+    points: uint64  # Total points accumulated since last rest (or payout)
+    difficulty: uint64  # Current difficulty for this farmer
+    payout_instructions: str  # This is where the pool will pay out rewards to the farmer
+    is_pool_member: bool  # If the farmer leaves the pool, this gets set to False

--- a/pool/singleton.py
+++ b/pool/singleton.py
@@ -18,7 +18,7 @@ from chia.types.coin_solution import CoinSolution
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32
 
-from record import FarmerRecord
+from .record import FarmerRecord
 
 log = logging
 log.basicConfig(level=logging.INFO)

--- a/pool/singleton.py
+++ b/pool/singleton.py
@@ -18,7 +18,7 @@ from chia.types.coin_solution import CoinSolution
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32
 
-from store import FarmerRecord
+from record import FarmerRecord
 
 log = logging
 log.basicConfig(level=logging.INFO)

--- a/pool/store.py
+++ b/pool/store.py
@@ -1,5 +1,4 @@
 import asyncio
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Set, List, Tuple, Dict
 
@@ -10,23 +9,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_solution import CoinSolution
 from chia.util.ints import uint64
 
-from chia.util.streamable import streamable, Streamable
-
-
-@dataclass(frozen=True)
-@streamable
-class FarmerRecord(Streamable):
-    launcher_id: bytes32  # This uniquely identifies the singleton on the blockchain (ID for this farmer)
-    p2_singleton_puzzle_hash: bytes32  # Derived from the launcher id, delay_time and delay_puzzle_hash
-    delay_time: uint64  # Backup time after which farmer can claim rewards directly, if pool unresponsive
-    delay_puzzle_hash: bytes32  # Backup puzzlehash to claim rewards
-    authentication_public_key: G1Element  # This is the latest public key of the farmer (signs all partials)
-    singleton_tip: CoinSolution  # Last coin solution that is buried in the blockchain, for this singleton
-    singleton_tip_state: PoolState  # Current state of the singleton
-    points: uint64  # Total points accumulated since last rest (or payout)
-    difficulty: uint64  # Current difficulty for this farmer
-    payout_instructions: str  # This is where the pool will pay out rewards to the farmer
-    is_pool_member: bool  # If the farmer leaves the pool, this gets set to False
+from record import FarmerRecord
 
 
 class PoolStore:

--- a/pool/store/abstract.py
+++ b/pool/store/abstract.py
@@ -1,0 +1,68 @@
+from abc import ABC, abstractmethod
+import asyncio
+from typing import Optional, Set, List, Tuple
+
+from chia.pools.pool_wallet_info import PoolState
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.coin_solution import CoinSolution
+from chia.util.ints import uint64
+
+from ..record import FarmerRecord
+
+
+class AbstractPoolStore(ABC):
+    """
+    Base class for asyncio-related pool stores.
+    """
+    def __init__(self):
+        self.lock = asyncio.Lock()
+
+    @abstractmethod
+    async def connect(self):
+        """Perform IO-related initialization"""
+
+    @abstractmethod
+    async def add_farmer_record(self, farmer_record: FarmerRecord):
+        """Persist a new Farmer in the store"""
+
+    @abstractmethod
+    async def get_farmer_record(self, launcher_id: bytes32) -> Optional[FarmerRecord]:
+        """Fetch a farmer record for given ``launcher_id``. Returns ``None`` if no record found"""
+
+    @abstractmethod
+    async def update_difficulty(self, launcher_id: bytes32, difficulty: uint64):
+        """Update difficulty for Farmer identified by ``launcher_id``"""
+
+    @abstractmethod
+    async def update_singleton(
+        self,
+        launcher_id: bytes32,
+        singleton_tip: CoinSolution,
+        singleton_tip_state: PoolState,
+        is_pool_member: bool,
+    ):
+        """Update Farmer's singleton-related data"""
+
+    @abstractmethod
+    async def get_pay_to_singleton_phs(self) -> Set[bytes32]:
+        """Fetch all puzzle hashes of Farmers in this pool, to scan the blockchain in search of them"""
+
+    @abstractmethod
+    async def get_farmer_records_for_p2_singleton_phs(self, puzzle_hashes: Set[bytes32]) -> List[FarmerRecord]:
+        """Fetch Farmers matching given puzzle hashes"""
+
+    @abstractmethod
+    async def get_farmer_points_and_payout_instructions(self) -> List[Tuple[uint64, bytes]]:
+        """Fetch all farmers and their respective payout instructions"""
+
+    @abstractmethod
+    async def clear_farmer_points(self) -> None:
+        """Rest all Farmers' points to 0"""
+
+    @abstractmethod
+    async def add_partial(self, launcher_id: bytes32, timestamp: uint64, difficulty: uint64):
+        """Register new partial and update corresponding Farmer's points"""
+
+    @abstractmethod
+    async def get_recent_partials(self, launcher_id: bytes32, count: int) -> List[Tuple[uint64, uint64]]:
+        """Fetch last ``count`` partials for Farmer identified by ``launcher_id``"""

--- a/pool/store/sqlite_store.py
+++ b/pool/store/sqlite_store.py
@@ -9,7 +9,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_solution import CoinSolution
 from chia.util.ints import uint64
 
-from record import FarmerRecord
+from ..record import FarmerRecord
 
 
 class PoolStore:

--- a/pool/store/sqlite_store.py
+++ b/pool/store/sqlite_store.py
@@ -1,4 +1,3 @@
-import asyncio
 from pathlib import Path
 from typing import Optional, Set, List, Tuple, Dict
 
@@ -9,19 +8,21 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_solution import CoinSolution
 from chia.util.ints import uint64
 
+from .abstract import AbstractPoolStore
 from ..record import FarmerRecord
 
 
-class PoolStore:
-    connection: aiosqlite.Connection
-    lock: asyncio.Lock
+class SqlitePoolStore(AbstractPoolStore):
+    """
+    Pool store based on SQLite.
+    """
+    def __init__(self, db_path: Path = Path('pooldb.sqlite')):
+        super().__init__()
+        self.db_path = db_path
+        self.connection: Optional[aiosqlite.Connection] = None
 
-    @classmethod
-    async def create(cls):
-        self = cls()
-        self.db_path = Path("pooldb.sqlite")
+    async def connect(self):
         self.connection = await aiosqlite.connect(self.db_path)
-        self.lock = asyncio.Lock()
         await self.connection.execute("pragma journal_mode=wal")
         await self.connection.execute("pragma synchronous=2")
         await self.connection.execute(
@@ -50,8 +51,6 @@ class PoolStore:
         await self.connection.execute("CREATE INDEX IF NOT EXISTS launcher_id_index on partial(launcher_id)")
 
         await self.connection.commit()
-
-        return self
 
     @staticmethod
     def _row_to_farmer_record(row) -> FarmerRecord:


### PR DESCRIPTION
The previous store has been renamed to `SqlitePoolStore` and is the default one.  As suggested in https://github.com/Chia-Network/pool-reference/issues/91 users can now write their own store implementations and use them with the pool. For this reason, an abstract class has been introduced.

To use a custom store, a users needs to do the following:

```
from pool.pool_server import start_pool_server
try:
    asyncio.run(start_pool_server(MyOwnPoolStoreClass()))
except KeyboardInterrupt:
    asyncio.run(stop())
```

Therefore this repository can now function as a framework, not just an end application.
For this reason, I changed all the imports to be relative to `pool` package, so they can function properly in any environment. I've also introduced a very simple `__main__.py` file, that allows to run the pool with `python -m pool`.