### PR TITLE
More consistent target_puzzle_hash specification

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -423,12 +423,13 @@ Request parameters:
 ```
 - launcher_id
 - authentication_token
+- target_puzzle_hash
 - signature
 ```
 
 Example request:
 ```
-https://poolurl.com/login?launcher_id=:launcher_id&authentication_token=:token&signature=:signature
+https://poolurl.com/login?launcher_id=:launcher_id&authentication_token=:token&target_puzzle_hash=:target_puzzle_hash&signature=:signature
 ```
 
 #### launcher_id

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -423,13 +423,12 @@ Request parameters:
 ```
 - launcher_id
 - authentication_token
-- target_puzzle_hash
 - signature
 ```
 
 Example request:
 ```
-https://poolurl.com/login?launcher_id=:launcher_id&authentication_token=:token&target_puzzle_hash=:target_puzzle_hash&signature=:signature
+https://poolurl.com/login?launcher_id=:launcher_id&authentication_token=:token&signature=:signature
 ```
 
 #### launcher_id
@@ -438,9 +437,6 @@ The unique identifier of the farmer's singleton, see [Farmer identification](#fa
 #### authentication_token
 See [Farmer authentication](#farmer-authentication) for the specification of
 `authentication_token`.
-
-#### target_puzzle_hash
-The pool's target puzzle hash, see [GET /pool_info](#get-pool_info)
 
 #### signature
 This is a BLS signature of the hashed serialization of the following data in the given order:
@@ -452,7 +448,8 @@ This is a BLS signature of the hashed serialization of the following data in the
 |target_puzzle_hash | bytes32 |
 |authentication_token | uint64 |
 
-where `method_name` must be the serialized string `"get_login"`, the parameters must be serialized and hashed
+where `method_name` must be the serialized string `"get_login"` and `target_puzzle_hash`
+is pool's target puzzle hash (see [GET /pool_info](#get-pool_info)). The parameters must be serialized and hashed
 according to [Signature validation](#signature-validation) and the signature must be signed by the private key of the
 `authentication_public_key` using the Augmented Scheme in the BLS IETF spec.
 


### PR DESCRIPTION
`target_puzzle_hash` parameter for was partially documented in `GET /login` documentation and not introduced yet in the implementation. This PR makes the documentation consistent.

It was not said anywhere, I think, but this, when implemented, will help pools to be hosted easily, meaning that a pool operator will be able to outsource his operation to a SaaS which will then handle most of the grunt work, at least for the `GET /login` part which doesn't handle any real money. Specifically I think this allows multiple pools to be hosted on the same domain and it allows a pool to change to a different domain. It also prevents attacks where one pool tries to steal an authentication cookie and use it to manage the account of a different pool the given user is a member of. It should at least be documented well. Preliminary look on `get_pool()` suggests that proper target_puzzle_hash verification should not be hard, but lets put that in a separate PR.