### PR TITLE
pool: Allow specifying an address for payout instructions

### DIFF
--- a/pool/pool.py
+++ b/pool/pool.py
@@ -607,7 +607,7 @@ class Pool:
             else:
                 difficulty = request.payload.suggested_difficulty
 
-            if not self.validate_payout_instructions(request.payload.payout_instructions):
+            if not await self.validate_payout_instructions(request.payload.payout_instructions):
                 return error_dict(
                     PoolErrorCode.INVALID_PAYOUT_INSTRUCTIONS,
                     f"Payout instructions must be an xch address or puzzle hash for this pool.",

--- a/pool/pool.py
+++ b/pool/pool.py
@@ -682,7 +682,7 @@ class Pool:
                 farmer_dict["authentication_public_key"] = request.payload.authentication_public_key
 
         if request.payload.payout_instructions is not None:
-            if not self.validate_payout_instructions(request.payload.payout_instructions):
+            if not await self.validate_payout_instructions(request.payload.payout_instructions):
                 return error_dict(
                     PoolErrorCode.INVALID_PAYOUT_INSTRUCTIONS,
                     f"Payout instructions must be an xch address or puzzle hash for this pool.",


### PR DESCRIPTION
Allows address or puzzle hash in POST and PUT farmer, for payout instructions. Before, only puzzle hash was allowed.
This makes the pool more robust, and means that a user does not need to figure out their puzzle hash to change this value.

Also, if the value is wrong, POST and PUT will return an error. 

I have not tested it yet. We need to make a corresponding change in chia-blockchain to set the value using the CLI