### PR TITLE
pool: Improve transaction (#201)

### DIFF
--- a/pool/store/abstract.py
+++ b/pool/store/abstract.py
@@ -25,6 +25,10 @@ class AbstractPoolStore(ABC):
         """Perform IO-related initialization"""
 
     @abstractmethod
+    async def tx(self):
+        """Performing Transactions for async with statement"""
+
+    @abstractmethod
     async def add_farmer_record(self, farmer_record: FarmerRecord, metadata: RequestMetadata):
         """Persist a new Farmer in the store"""
 
@@ -55,12 +59,15 @@ class AbstractPoolStore(ABC):
         """Fetch Farmers matching given puzzle hashes"""
 
     @abstractmethod
-    async def get_farmer_points_and_payout_instructions(self) -> List[Tuple[uint64, bytes]]:
+    async def get_farmer_launcher_id_and_points_and_payout_instructions(self) -> List[Tuple[bytes32, uint64, bytes32]]:
         """Fetch all farmers and their respective payout instructions"""
 
     @abstractmethod
-    async def clear_farmer_points(self) -> None:
-        """Rest all Farmers' points to 0"""
+    async def clear_farmer_points(self, auto_commit: bool = True) -> None:
+        """
+        Rest all Farmers' points to 0
+        auto_commit decides whether to commit the transaction.
+        """
 
     @abstractmethod
     async def add_partial(self, launcher_id: bytes32, timestamp: uint64, difficulty: uint64):
@@ -69,3 +76,56 @@ class AbstractPoolStore(ABC):
     @abstractmethod
     async def get_recent_partials(self, launcher_id: bytes32, count: int) -> List[Tuple[uint64, uint64]]:
         """Fetch last ``count`` partials for Farmer identified by ``launcher_id``"""
+
+    @abstractmethod
+    async def add_payment(
+        self,
+        launcher_id: bytes32,
+        puzzle_hash: bytes32,
+        amount: uint64,
+        points: int,
+        timestamp: uint64,
+        is_payment: bool,
+        auto_commit: bool = True,
+    ):
+        """
+        Persist a new payment record in the store
+        auto_commit decides whether to commit the transaction.
+        """
+
+    @abstractmethod
+    async def update_is_payment(
+        self,
+        launcher_id_and_timestamp: List[Tuple[bytes32, uint64]],
+        auto_commit: bool = True,
+    ):
+        """
+        Update is_payment is True for payment records identified by ``launcher_id`` and ``timestamp``.
+        auto_commit decides whether to commit the transaction.
+        """
+
+    @abstractmethod
+    async def get_pending_payment_records(self, count: int) -> List[
+        Tuple[bytes32, bytes32, uint64, uint64, uint64, bool, bool]
+    ]:
+        """Fetch ``count`` pending payment records"""
+
+    @abstractmethod
+    async def get_pending_payment_count(self) -> int:
+        """Fetch pending payment records count"""
+
+    @abstractmethod
+    async def get_confirming_payment_records(self) -> List[bytes32]:
+        """Fetch confirming payment records"""
+
+    @abstractmethod
+    async def update_transaction_id(
+        self,
+        launcher_id_and_timestamp: List[Tuple[bytes32, uint64]],
+        transaction_id: bytes32,
+    ):
+        """Update transaction_id for payment records identified by ``launcher_id`` and ``timestamp``."""
+
+    @abstractmethod
+    async def update_is_confirmed(self, transaction_id: bytes32):
+        """Update is_confirmed is True for payment records identified by ``transaction_id``"""


### PR DESCRIPTION
My general idea is to replace the old pending_payments queue with a database table(payment), to persist the data. make sure that afte the subtract the points, pending payment records still exists when the program exits unexpectedly, and the transaction failure retry can be achieved, finally moved confirm payment to a new task.