### PR TITLE
Await validate_payout_instructions in put_farmer

### DIFF
--- a/pool/pool.py
+++ b/pool/pool.py
@@ -696,7 +696,7 @@ class Pool:
                 farmer_dict["authentication_public_key"] = request.payload.authentication_public_key
 
         if request.payload.payout_instructions is not None:
-            new_ph: Optional[str] = self.validate_payout_instructions(request.payload.payout_instructions)
+            new_ph: Optional[str] = await self.validate_payout_instructions(request.payload.payout_instructions)
             response_dict["payout_instructions"] = new_ph
             if new_ph:
                 farmer_dict["payout_instructions"] = new_ph


### PR DESCRIPTION
As reported on the Chia Pool Founder Discord channel by XCH Garden / OpenChia:

```
INFO:root:put_farmer response {'authentication_public_key': False, 'payout_instructions': <coroutine object Pool.validate_payout_instructions at 0x7f986d813340>}, launcher_id: <launcher id>
WARNING:pool.pool_server:Error while handling message: Traceback (most recent call last):
  File "/home/pyryk/mainnet/pool-reference/pool/pool_server.py", line 85, in inner
    res_object = await f(request)
  File "/home/pyryk/mainnet/pool-reference/pool/pool_server.py", line 209, in put_farmer
    return obj_to_response(put_farmer_response)
  File "/home/pyryk/mainnet/pool-reference/venv/lib/python3.8/site-packages/chia/util/json_util.py", line 39, in obj_to_response
    json_str = dict_to_json_str(o)
  File "/home/pyryk/mainnet/pool-reference/venv/lib/python3.8/site-packages/chia/util/json_util.py", line 31, in dict_to_json_str
    json_str = json.dumps(o, cls=EnhancedJSONEncoder, sort_keys=True)
  File "/usr/lib/python3.8/json/__init__.py", line 234, in dumps
    return cls(
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/home/pyryk/mainnet/pool-reference/venv/lib/python3.8/site-packages/chia/util/json_util.py", line 24, in default
    return super().default(o)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type coroutine is not JSON serializable
```