### PR TITLE
Update aiohttp and pytest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,15 @@
 name: black-action
-on: [push, pull_request]
+on: 
+  push:
+    branches: main
+  pull_request:
 jobs:
   linter_name:
     name: runner & black formatter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+
       - uses: psf/black@stable
         with:
           black_args: ". --check"

--- a/pool/store/mariadb_store.py
+++ b/pool/store/mariadb_store.py
@@ -16,8 +16,8 @@ from ..util import RequestMetadata
 from .abstract import AbstractPoolStore
 
 pymysql.converters.encoders[uint64] = pymysql.converters.escape_int
-pymysql.converters.conversions = pymysql.converters.encoders.copy()  # type:ignore
-pymysql.converters.conversions.update(pymysql.converters.decoders)  # type:ignore
+pymysql.converters.conversions = pymysql.converters.encoders.copy()  # type: ignore
+pymysql.converters.conversions.update(pymysql.converters.decoders)  # type: ignore
 
 
 class MariadbPoolStore(AbstractPoolStore):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ chia-blockchain==2.4.4
 blspy==2.0.3
 setuptools~=75.6.0
 aiosqlite==0.20.0
-aiohttp==3.13.3
-pytest==8.3.4
+aiohttp==3.14.1
+pytest==9.0.3
 PyYAML==6.0.2
 PyMySQL==1.1.1

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ dependencies = [
     "chia_rs>=0.5.2",
     "setuptools>=56.1,<75.7",
     "aiosqlite==0.20.0",
-    "aiohttp==3.13.3",
-    "pytest==8.3.4",
+    "aiohttp==3.14.1",
+    "pytest==9.0.3",
     "PyMySQL==1.1.1",
 ]
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> aiohttp powers the pool HTTP server in `pool_server.py`; a minor release bump could affect runtime behavior, while pytest 9 may require test suite adjustments.
> 
> **Overview**
> Bumps **`aiohttp`** from `3.13.3` to `3.14.1` and **`pytest`** from `8.3.4` to `9.0.3` in both `requirements.txt` and `setup.py` install dependencies.
> 
> The **black** GitHub Action workflow now runs on **push to `main` only** (instead of every push) and still on all pull requests, and **`actions/checkout`** is upgraded from **v6** to **v7**.
> 
> Two **`# type: ignore`** comments in `mariadb_store.py` are reformatted to include a space after `#` (`type: ignore`), matching typical style/linter expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcad5aa14e53334f1367e9aa986232a774e680b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->