### PR TITLE
Update setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 chia-blockchain==2.4.4
 blspy==2.0.3
-setuptools~=75.6.0
+setuptools>=78.1.1
 aiosqlite==0.20.0
 aiohttp==3.14.1
 pytest==9.0.3

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def read(fname):
 dependencies = [
     "chia-blockchain==2.4.4",
     "chia_rs>=0.5.2",
-    "setuptools>=56.1,<75.7",
+    "setuptools>=78.1.1",
     "aiosqlite==0.20.0",
     "aiohttp==3.14.1",
     "pytest==9.0.3",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only constraint change with no runtime or pool logic touched; main risk is rare install/build incompatibility on older Python or CI images.
> 
> **Overview**
> Raises the **setuptools** floor from the previous `~75.6` / `>=56.1,<75.7` range to **`setuptools>=78.1.1`** in both `requirements.txt` and `setup.py` `install_requires`.
> 
> No application code changes; install and packaging environments will pull a newer setuptools on fresh installs or upgrades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57224be943cc1ea4c9eca352324696b8d87b8a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->